### PR TITLE
Harmony 1. Added support for event driven architecture. 

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -40,7 +40,7 @@ dependencies {
     implementation 'org.mapstruct:mapstruct:1.5.5.Final'
     implementation 'io.projectreactor.kafka:reactor-kafka:1.3.21'
     implementation 'org.springframework.kafka:spring-kafka:3.0.9'
-    implementation 'com.odeyalo.sonata.suite:brokers:0.0.3-SNAPSHOT'
+    implementation 'com.odeyalo.sonata.suite:brokers:0.0.4-SNAPSHOT'
     runtimeOnly 'org.postgresql:postgresql'
     runtimeOnly 'org.postgresql:r2dbc-postgresql'
     annotationProcessor 'org.mapstruct:mapstruct-processor:1.5.5.Final'

--- a/src/main/java/com/odeyalo/sonata/harmony/model/Track.java
+++ b/src/main/java/com/odeyalo/sonata/harmony/model/Track.java
@@ -4,6 +4,8 @@ import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Value;
 
+import java.net.URI;
+
 @Value
 @AllArgsConstructor(staticName = "of")
 @Builder(toBuilder = true)
@@ -15,6 +17,7 @@ public class Track {
     boolean hasLyrics;
     int discNumber;
     int index;
+    URI trackUrl;
     ArtistContainer artists;
     SimplifiedAlbumRelease album;
 

--- a/src/main/java/com/odeyalo/sonata/harmony/service/event/AbstractEventPublisher.java
+++ b/src/main/java/com/odeyalo/sonata/harmony/service/event/AbstractEventPublisher.java
@@ -9,7 +9,7 @@ import reactor.core.publisher.Mono;
  * @param <T> - type of the event to publish
  */
 @Log4j2
-public class AbstractEventPublisher<T extends SonataEvent> implements EventPublisher<T> {
+public abstract class AbstractEventPublisher<T extends SonataEvent> implements EventPublisher<T> {
     private final EventPublisherDelegate eventPublisherDelegate;
 
     public AbstractEventPublisher(EventPublisherDelegate eventPublisherDelegate) {

--- a/src/main/java/com/odeyalo/sonata/harmony/service/event/AbstractEventPublisher.java
+++ b/src/main/java/com/odeyalo/sonata/harmony/service/event/AbstractEventPublisher.java
@@ -1,0 +1,24 @@
+package com.odeyalo.sonata.harmony.service.event;
+
+import com.odeyalo.sonata.suite.brokers.events.SonataEvent;
+import lombok.extern.log4j.Log4j2;
+import reactor.core.publisher.Mono;
+
+/**
+ * Abstract implementation of {@link EventPublisher} that publish events using {@link EventPublisherDelegate}
+ * @param <T> - type of the event to publish
+ */
+@Log4j2
+public class AbstractEventPublisher<T extends SonataEvent> implements EventPublisher<T> {
+    private final EventPublisherDelegate eventPublisherDelegate;
+
+    public AbstractEventPublisher(EventPublisherDelegate eventPublisherDelegate) {
+        this.eventPublisherDelegate = eventPublisherDelegate;
+        log.info("Using the following delegate to publish the events: {}", eventPublisherDelegate);
+    }
+
+    @Override
+    public Mono<Void> publishEvent(T event) {
+        return eventPublisherDelegate.publishEvent(event);
+    }
+}

--- a/src/main/java/com/odeyalo/sonata/harmony/service/event/BasicAlbumInfoUploadedEventPublisher.java
+++ b/src/main/java/com/odeyalo/sonata/harmony/service/event/BasicAlbumInfoUploadedEventPublisher.java
@@ -1,0 +1,19 @@
+package com.odeyalo.sonata.harmony.service.event;
+
+import com.odeyalo.sonata.suite.brokers.events.album.BasicAlbumInfoUploadedEvent;
+import lombok.extern.log4j.Log4j2;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Component;
+
+/**
+ * Publish the {@link BasicAlbumInfoUploadedEvent} using {@link EventPublisherDelegate}
+ */
+@Component
+@Log4j2
+public class BasicAlbumInfoUploadedEventPublisher extends AbstractEventPublisher<BasicAlbumInfoUploadedEvent> {
+
+    @Autowired
+    public BasicAlbumInfoUploadedEventPublisher(EventPublisherDelegate eventPublisherDelegate) {
+        super(eventPublisherDelegate);
+    }
+}

--- a/src/main/java/com/odeyalo/sonata/harmony/service/event/impl/AlbumUploadingFullyFinishedEventPublisher.java
+++ b/src/main/java/com/odeyalo/sonata/harmony/service/event/impl/AlbumUploadingFullyFinishedEventPublisher.java
@@ -1,24 +1,18 @@
 package com.odeyalo.sonata.harmony.service.event.impl;
 
-import com.odeyalo.sonata.harmony.service.event.EventPublisher;
+import com.odeyalo.sonata.harmony.service.event.AbstractEventPublisher;
 import com.odeyalo.sonata.harmony.service.event.EventPublisherDelegate;
 import com.odeyalo.sonata.suite.brokers.events.album.AlbumUploadingFullyFinishedEvent;
 import lombok.extern.log4j.Log4j2;
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
-import reactor.core.publisher.Mono;
 
 @Component
 @Log4j2
-public class AlbumUploadingFullyFinishedEventPublisher implements EventPublisher<AlbumUploadingFullyFinishedEvent> {
-    private final EventPublisherDelegate eventPublisherDelegate;
+public class AlbumUploadingFullyFinishedEventPublisher extends AbstractEventPublisher<AlbumUploadingFullyFinishedEvent> {
 
+    @Autowired
     public AlbumUploadingFullyFinishedEventPublisher(EventPublisherDelegate eventPublisherDelegate) {
-        this.eventPublisherDelegate = eventPublisherDelegate;
-        log.info("Using the following delegate to publish the events: {}", eventPublisherDelegate);
-    }
-
-    @Override
-    public Mono<Void> publishEvent(AlbumUploadingFullyFinishedEvent event) {
-        return eventPublisherDelegate.publishEvent(event);
+        super(eventPublisherDelegate);
     }
 }

--- a/src/main/java/com/odeyalo/sonata/harmony/service/event/impl/BasicAlbumInfoUploadedEventPublisher.java
+++ b/src/main/java/com/odeyalo/sonata/harmony/service/event/impl/BasicAlbumInfoUploadedEventPublisher.java
@@ -1,5 +1,7 @@
-package com.odeyalo.sonata.harmony.service.event;
+package com.odeyalo.sonata.harmony.service.event.impl;
 
+import com.odeyalo.sonata.harmony.service.event.AbstractEventPublisher;
+import com.odeyalo.sonata.harmony.service.event.EventPublisherDelegate;
 import com.odeyalo.sonata.suite.brokers.events.album.BasicAlbumInfoUploadedEvent;
 import lombok.extern.log4j.Log4j2;
 import org.springframework.beans.factory.annotation.Autowired;

--- a/src/main/java/com/odeyalo/sonata/harmony/support/converter/TrackConverter.java
+++ b/src/main/java/com/odeyalo/sonata/harmony/support/converter/TrackConverter.java
@@ -16,6 +16,7 @@ public interface TrackConverter {
 
     @Mapping(source = "hasLyrics", target = "hasLyrics")
     @Mapping(source = "name", target = "trackName")
+    @Mapping(expression = "java( java.net.URI.create(entity.getTrackUrl()))", target = "trackUrl")
     Track toTrack(SimplifiedTrackEntity entity);
 
     default Track toTrack(SimplifiedTrackEntity entity, SimplifiedAlbumRelease album) {

--- a/src/main/java/com/odeyalo/sonata/harmony/support/converter/external/BasicAlbumInfoUploadedPayloadConverter.java
+++ b/src/main/java/com/odeyalo/sonata/harmony/support/converter/external/BasicAlbumInfoUploadedPayloadConverter.java
@@ -1,0 +1,51 @@
+package com.odeyalo.sonata.harmony.support.converter.external;
+
+import com.odeyalo.sonata.harmony.model.AlbumRelease;
+import com.odeyalo.sonata.harmony.model.ReleaseDate;
+import com.odeyalo.sonata.harmony.repository.r2dbc.support.release.ReleaseDateEncoder;
+import com.odeyalo.sonata.suite.brokers.events.album.data.BasicAlbumInfoUploadedPayload;
+import com.odeyalo.sonata.suite.brokers.events.album.data.CoverImage;
+import org.mapstruct.AfterMapping;
+import org.mapstruct.Mapper;
+import org.mapstruct.Mapping;
+import org.mapstruct.MappingTarget;
+import org.springframework.beans.factory.annotation.Autowired;
+
+import java.net.URI;
+
+@Mapper(componentModel = "spring", uses = {
+        ArtistContainerDtoConverter.class,
+        UploadedTrackSimplifiedInfoContainerDtoConverter.class
+})
+public abstract class BasicAlbumInfoUploadedPayloadConverter {
+
+    @Autowired
+    ReleaseDateEncoder<String> releaseDateEncoder;
+
+
+    @Mapping(source = "name", target = "albumName")
+    @Mapping(source = "tracks", target = "uploadedTracks")
+    @Mapping(source = "totalTracksCount", target = "trackCount")
+    public abstract BasicAlbumInfoUploadedPayload toBasicAlbumInfoUploadedPayload(AlbumRelease albumRelease);
+
+
+    @AfterMapping
+    public void releaseDateEnhancer(@MappingTarget BasicAlbumInfoUploadedPayload.BasicAlbumInfoUploadedPayloadBuilder builder,
+                                    AlbumRelease release) {
+        ReleaseDate releaseDate = release.getReleaseDate();
+
+        builder
+                .releaseDateAsString(releaseDateEncoder.encodeReleaseDate(releaseDate))
+                .releaseDatePrecision(releaseDate.getPrecision().name());
+    }
+
+    @AfterMapping
+    public void imageEnhancer(@MappingTarget BasicAlbumInfoUploadedPayload.BasicAlbumInfoUploadedPayloadBuilder builder,
+                              AlbumRelease release) {
+        String imageUrl = release.getImages().get(0).getUrl();
+
+        builder.coverImage(
+                CoverImage.builder().uri(URI.create(imageUrl)).build()
+        );
+    }
+}

--- a/src/main/java/com/odeyalo/sonata/harmony/support/converter/external/UploadedTrackSimplifiedInfoContainerDtoConverter.java
+++ b/src/main/java/com/odeyalo/sonata/harmony/support/converter/external/UploadedTrackSimplifiedInfoContainerDtoConverter.java
@@ -1,0 +1,26 @@
+package com.odeyalo.sonata.harmony.support.converter.external;
+
+import com.odeyalo.sonata.harmony.model.TrackContainer;
+import com.odeyalo.sonata.suite.brokers.events.album.data.UploadedTrackSimplifiedInfoContainerDto;
+import com.odeyalo.sonata.suite.brokers.events.album.data.UploadedTrackSimplifiedInfoDto;
+import org.mapstruct.InjectionStrategy;
+import org.mapstruct.Mapper;
+import org.springframework.beans.factory.annotation.Autowired;
+
+import java.util.List;
+
+@Mapper(componentModel = "spring",
+        uses = UploadedTrackSimplifiedInfoDtoConverter.class,
+        injectionStrategy = InjectionStrategy.CONSTRUCTOR)
+public abstract class UploadedTrackSimplifiedInfoContainerDtoConverter {
+    @Autowired
+    UploadedTrackSimplifiedInfoDtoConverter uploadedTrackSimplifiedInfoDtoConverter;
+
+    public UploadedTrackSimplifiedInfoContainerDto toUploadedTrackSimplifiedInfoContainerDto(TrackContainer container) {
+        List<UploadedTrackSimplifiedInfoDto> list = container.stream()
+                .map(uploadedTrackSimplifiedInfoDtoConverter::toUploadedTrackSimplifiedInfoDto)
+                .toList();
+
+        return UploadedTrackSimplifiedInfoContainerDto.fromCollection(list);
+    }
+}

--- a/src/main/java/com/odeyalo/sonata/harmony/support/converter/external/UploadedTrackSimplifiedInfoDtoConverter.java
+++ b/src/main/java/com/odeyalo/sonata/harmony/support/converter/external/UploadedTrackSimplifiedInfoDtoConverter.java
@@ -1,0 +1,15 @@
+package com.odeyalo.sonata.harmony.support.converter.external;
+
+import com.odeyalo.sonata.harmony.model.Track;
+import com.odeyalo.sonata.suite.brokers.events.album.data.UploadedTrackSimplifiedInfoDto;
+import org.mapstruct.Mapper;
+import org.mapstruct.Mapping;
+
+@Mapper(componentModel = "spring", uses = ArtistContainerDtoConverter.class)
+public interface UploadedTrackSimplifiedInfoDtoConverter {
+
+    @Mapping(source = "trackName", target = "name")
+    @Mapping(source = "trackUrl", target = "uri")
+    UploadedTrackSimplifiedInfoDto toUploadedTrackSimplifiedInfoDto(Track track);
+
+}

--- a/src/test/java/com/odeyalo/sonata/harmony/service/EventPublisherAlbumReleaseUploaderDecoratorTest.java
+++ b/src/test/java/com/odeyalo/sonata/harmony/service/EventPublisherAlbumReleaseUploaderDecoratorTest.java
@@ -1,0 +1,96 @@
+package com.odeyalo.sonata.harmony.service;
+
+import com.odeyalo.sonata.harmony.model.*;
+import com.odeyalo.sonata.harmony.service.album.TrackUploadTarget;
+import com.odeyalo.sonata.harmony.service.album.TrackUploadTargetContainer;
+import com.odeyalo.sonata.harmony.service.album.UploadAlbumReleaseInfo;
+import com.odeyalo.sonata.harmony.service.event.impl.BasicAlbumInfoUploadedEventPublisher;
+import com.odeyalo.sonata.harmony.support.converter.external.BasicAlbumInfoUploadedPayloadConverter;
+import org.jetbrains.annotations.NotNull;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mockito;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.context.annotation.Import;
+import org.springframework.http.codec.multipart.FilePart;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
+import reactor.core.publisher.Flux;
+import reactor.core.publisher.Mono;
+import testing.faker.AlbumReleaseFaker;
+import testing.faker.ImageContainerFaker;
+import testing.faker.ImageFaker;
+import testing.spring.MapStructBeansBootstrapConfiguration;
+import testing.spring.web.FilePartStub;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(SpringExtension.class)
+@Import(MapStructBeansBootstrapConfiguration.class)
+class EventPublisherAlbumReleaseUploaderDecoratorTest {
+
+    @SuppressWarnings("SpringJavaInjectionPointsAutowiringInspection")
+    @Autowired
+    BasicAlbumInfoUploadedPayloadConverter converter;
+
+    @Test
+    void shouldPublishEventOnSuccess() {
+        Image image = ImageFaker.create().get();
+        AlbumRelease albumRelease = AlbumReleaseFaker.create().id(10L).images(ImageContainer.one(image)).get();
+        BasicAlbumInfoUploadedEventPublisher publisher = Mockito.mock(BasicAlbumInfoUploadedEventPublisher.class);
+
+        when(publisher.publishEvent(any())).thenReturn(Mono.empty());
+
+        EventPublisherAlbumReleaseUploaderDecorator testable = new EventPublisherAlbumReleaseUploaderDecorator(
+                (info, tracks, coverImage) -> Mono.just(albumRelease),
+                publisher,
+                converter
+        );
+
+        UploadAlbumReleaseInfo releaseInfo = createUploadAlbumReleaseInfo();
+        Mono<FilePart> albumCoverFile = prepareAlbumCoverFile();
+        Flux<FilePart> trackFiles = prepareTrackFiles();
+
+        testable.uploadAlbumRelease(releaseInfo, trackFiles, albumCoverFile).block();
+
+        verify(publisher, times(1)).publishEvent(any());
+    }
+
+
+    @NotNull
+    private static Mono<FilePart> prepareAlbumCoverFile() {
+        return Mono.just(new FilePartStub(Flux.empty()));
+    }
+
+    @NotNull
+    private static Flux<FilePart> prepareTrackFiles() {
+        return Flux.just(new FilePartStub(Flux.empty(), 2000, "track.mp3"));
+    }
+
+    @NotNull
+    private static UploadAlbumReleaseInfo createUploadAlbumReleaseInfo() {
+        ArtistContainer artists = ArtistContainer.solo(Artist.of("booones", "BONES"));
+
+        TrackUploadTargetContainer tracks = TrackUploadTargetContainer.builder()
+                .item(TrackUploadTarget.builder()
+                        .trackName("dudeness")
+                        .durationMs(1000L)
+                        .isExplicit(true)
+                        .hasLyrics(true)
+                        .fileId("track.mp3")
+                        .artists(artists)
+                        .discNumber(1)
+                        .index(0)
+                        .build())
+                .build();
+
+        return UploadAlbumReleaseInfo.builder()
+                .albumName("something")
+                .totalTracksCount(1)
+                .albumType(AlbumType.SINGLE)
+                .tracks(tracks)
+                .releaseDate(ReleaseDate.onlyYear(2020))
+                .artists(artists)
+                .build();
+    }
+}

--- a/src/test/java/com/odeyalo/sonata/harmony/support/converter/TrackConverterTest.java
+++ b/src/test/java/com/odeyalo/sonata/harmony/support/converter/TrackConverterTest.java
@@ -14,12 +14,15 @@ import org.springframework.context.annotation.Import;
 import org.springframework.test.context.junit.jupiter.SpringExtension;
 import testing.spring.MapStructBeansBootstrapConfiguration;
 
+import java.net.URI;
+
 import static org.assertj.core.api.Assertions.assertThat;
 
 @ExtendWith(SpringExtension.class)
 @Import(MapStructBeansBootstrapConfiguration.class)
 class TrackConverterTest {
 
+    @SuppressWarnings("SpringJavaInjectionPointsAutowiringInspection")
     @Autowired
     TrackConverter trackConverter;
 
@@ -50,6 +53,7 @@ class TrackConverterTest {
         assertThat(result.getDurationMs()).isEqualTo(expected.getDurationMs());
         assertThat(result.isExplicit()).isEqualTo(expected.isExplicit());
         assertThat(result.hasLyrics()).isEqualTo(expected.hasLyrics());
+        assertThat(result.getTrackUrl()).isEqualTo(URI.create(expected.getTrackUrl()));
     }
 
     private static TrackEntity createTrackEntity() {
@@ -61,6 +65,7 @@ class TrackConverterTest {
                 .artists(ArtistContainerEntity.solo(ArtistEntity.of(1L, "id", "corn wave")))
                 .discNumber(1)
                 .durationMs(1488L)
+                .trackUrl("http://localhost:3000/track/123")
                 .build();
     }
 

--- a/src/test/java/com/odeyalo/sonata/harmony/support/converter/external/BasicAlbumInfoUploadedPayloadConverterTest.java
+++ b/src/test/java/com/odeyalo/sonata/harmony/support/converter/external/BasicAlbumInfoUploadedPayloadConverterTest.java
@@ -1,0 +1,32 @@
+package com.odeyalo.sonata.harmony.support.converter.external;
+
+import com.odeyalo.sonata.harmony.model.AlbumRelease;
+import com.odeyalo.sonata.suite.brokers.events.album.data.BasicAlbumInfoUploadedPayload;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.context.annotation.Import;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
+import testing.faker.AlbumReleaseFaker;
+import testing.spring.MapStructBeansBootstrapConfiguration;
+
+import static org.assertj.core.api.Assertions.*;
+
+@ExtendWith(SpringExtension.class)
+@Import(MapStructBeansBootstrapConfiguration.class)
+class BasicAlbumInfoUploadedPayloadConverterTest {
+
+    @SuppressWarnings("SpringJavaInjectionPointsAutowiringInspection")
+    @Autowired
+    BasicAlbumInfoUploadedPayloadConverter testable;
+
+    @Test
+    void shouldConvertName() {
+        AlbumRelease expected = AlbumReleaseFaker.create().id(10L).get();
+
+        BasicAlbumInfoUploadedPayload result = testable.toBasicAlbumInfoUploadedPayload(expected);
+
+        assertThat(result.getAlbumName()).isEqualTo(expected.getName());
+        assertThat(result.getTrackCount()).isEqualTo(expected.getTotalTracksCount());
+    }
+}

--- a/src/test/java/com/odeyalo/sonata/harmony/support/converter/external/UploadedTrackSimplifiedInfoDtoConverterTest.java
+++ b/src/test/java/com/odeyalo/sonata/harmony/support/converter/external/UploadedTrackSimplifiedInfoDtoConverterTest.java
@@ -1,0 +1,35 @@
+package com.odeyalo.sonata.harmony.support.converter.external;
+
+import com.odeyalo.sonata.harmony.model.Track;
+import com.odeyalo.sonata.suite.brokers.events.album.data.UploadedTrackSimplifiedInfoDto;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.context.annotation.Import;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
+import testing.faker.TrackFaker;
+import testing.spring.MapStructBeansBootstrapConfiguration;
+
+import static org.assertj.core.api.Assertions.*;
+
+
+@ExtendWith(SpringExtension.class)
+@Import(MapStructBeansBootstrapConfiguration.class)
+class UploadedTrackSimplifiedInfoDtoConverterTest {
+
+    @SuppressWarnings("SpringJavaInjectionPointsAutowiringInspection")
+    @Autowired
+    UploadedTrackSimplifiedInfoDtoConverter testable;
+
+    @Test
+    void shouldConvertFromTrack() {
+        Track expected = TrackFaker.create().id("hello").get();
+
+        UploadedTrackSimplifiedInfoDto result = testable.toUploadedTrackSimplifiedInfoDto(expected);
+
+        assertThat(result.getName()).isEqualTo(expected.getTrackName());
+        assertThat(result.getId()).isEqualTo(expected.getId());
+        assertThat(result.getUri()).isEqualTo(expected.getTrackUrl());
+        assertThat(result.getArtists()).hasSize(expected.getArtists().size());
+    }
+}

--- a/src/test/java/testing/faker/SimplifiedTrackEntityFaker.java
+++ b/src/test/java/testing/faker/SimplifiedTrackEntityFaker.java
@@ -6,6 +6,8 @@ import com.odeyalo.sonata.harmony.entity.SimplifiedTrackEntity;
 import lombok.AccessLevel;
 import lombok.experimental.FieldDefaults;
 
+import java.util.UUID;
+
 @FieldDefaults(level = AccessLevel.PRIVATE, makeFinal = true)
 public class SimplifiedTrackEntityFaker {
     public static final int FIRST_TRACK_INDEX = 0;
@@ -21,6 +23,7 @@ public class SimplifiedTrackEntityFaker {
                 .artists(artists)
                 .hasLyrics(faker.random().nextBoolean())
                 .explicit(faker.random().nextBoolean())
+                .trackUrl("https://s3.aws.com/odeyalo/tracks/" + UUID.randomUUID())
                 .durationMs(Long.valueOf(faker.random().nextInt(1000, 100_000)));
     }
 

--- a/src/test/java/testing/faker/TrackFaker.java
+++ b/src/test/java/testing/faker/TrackFaker.java
@@ -7,6 +7,9 @@ import com.odeyalo.sonata.harmony.model.Track;
 import lombok.AccessLevel;
 import lombok.experimental.FieldDefaults;
 
+import java.net.URI;
+import java.util.UUID;
+
 @FieldDefaults(level = AccessLevel.PRIVATE, makeFinal = true)
 public class TrackFaker {
     Track.TrackBuilder builder = Track.builder();
@@ -20,7 +23,8 @@ public class TrackFaker {
                 .artists(ArtistContainerFaker.create().get())
                 .hasLyrics(faker.random().nextBoolean())
                 .isExplicit(faker.random().nextBoolean())
-                .durationMs(faker.random().nextInt(1000, 100_000));
+                .durationMs(faker.random().nextInt(1000, 100_000))
+                .trackUrl(URI.create("https://s3.aws.com/tracks/" + UUID.randomUUID()));
     }
 
     public static TrackFaker create() {

--- a/src/test/java/testing/faker/TrackFaker.java
+++ b/src/test/java/testing/faker/TrackFaker.java
@@ -17,7 +17,9 @@ public class TrackFaker {
     Faker faker = Faker.instance();
 
     public TrackFaker(int index, int discNumber) {
-        builder.index(index)
+        builder
+                .id(UUID.randomUUID().toString())
+                .index(index)
                 .discNumber(discNumber)
                 .trackName(faker.funnyName().name())
                 .artists(ArtistContainerFaker.create().get())


### PR DESCRIPTION
Added support for event driven architecture by changing the events. Make small refactor of classes, added tests. 
Added mocks for kafka gateways.

Implemented 

> Replace the AlbumUploadingFullyFinishedEvent with BasicAlbumInfoUploadedEvent. It will run other tasks instead indicating that album was fully uploaded

from https://github.com/Project-Sonata/Harmony/issues/16